### PR TITLE
Add settings to hide UniversalViewer

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -96,14 +96,16 @@ class Module extends AbstractModule
     public function handleViewBrowseAfterItem(Event $event): void
     {
         $view = $event->getTarget();
-        $services = $this->getServiceLocator();
-        // Note: there is no item-set show, but a special case for items browse.
-        $isItemSetShow = (bool) $services->get('Application')
-            ->getMvcEvent()->getRouteMatch()->getParam('item-set-id');
-        if ($isItemSetShow) {
-            echo $view->universalViewer($view->itemSet);
-        } elseif ($this->iiifServerIsActive()) {
-            echo $view->universalViewer($view->items);
+        if ($view->siteSetting('universalviewer_append_to_item_view_browse', true)) {
+            $services = $this->getServiceLocator();
+            // Note: there is no item-set show, but a special case for items browse.
+            $isItemSetShow = (bool) $services->get('Application')
+                ->getMvcEvent()->getRouteMatch()->getParam('item-set-id');
+            if ($isItemSetShow) {
+                echo $view->universalViewer($view->itemSet);
+            } elseif ($this->iiifServerIsActive()) {
+                echo $view->universalViewer($view->items);
+            }
         }
     }
 
@@ -114,13 +116,17 @@ class Module extends AbstractModule
         }
 
         $view = $event->getTarget();
-        echo $view->universalViewer($view->itemSets);
+        if ($view->siteSetting('universalviewer_append_to_itemset_view_browse', true)) {
+            echo $view->universalViewer($view->itemSets);
+        }
     }
 
     public function handleViewShowAfterItem(Event $event): void
     {
         $view = $event->getTarget();
-        echo $view->universalViewer($view->item);
+        if ($view->siteSetting('universalviewer_append_to_item_view_show', true)) {
+            echo $view->universalViewer($view->item);
+        }
     }
 
     protected function iiifServerIsActive()

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -141,6 +141,9 @@ return [
         ],
         'site_settings' => [
             'universalviewer_version' => '3',
+            'universalviewer_append_to_item_view_show' => '1',
+            'universalviewer_append_to_item_view_browse' => '1',
+            'universalviewer_append_to_itemset_view_browse' => '1',
         ],
     ],
 ];

--- a/src/Form/SiteSettingsFieldset.php
+++ b/src/Form/SiteSettingsFieldset.php
@@ -27,6 +27,30 @@ class SiteSettingsFieldset extends Fieldset
                     'value' => '3',
                 ],
             ])
+            ->add([
+                'name' => 'universalviewer_append_to_item_view_show',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Show UniversalViewer on item page', // @translate
+                    'use_hidden_element' => true,
+                ],
+            ])
+            ->add([
+                'name' => 'universalviewer_append_to_item_view_browse',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Show UniversalViewer on item browse page', // @translate
+                    'use_hidden_element' => true,
+                ],
+            ])
+            ->add([
+                'name' => 'universalviewer_append_to_itemset_view_browse',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Show UniversalViewer on item set browse page', // @translate
+                    'use_hidden_element' => true,
+                ],
+            ])
         ;
     }
 }


### PR DESCRIPTION
This patch adds 3 site settings that allow to enable/disable UniversalViewer on some pages. The pages affected are:
- item "show" page
- item "browse" page
- itemset "browse" page

These settings are enabled by default, so UniversalViewer is still displayed everywhere, unless explicitely disabled